### PR TITLE
feat: VNDocumentCameraViewController 오버레이 시도 구현

### DIFF
--- a/re-live/Info.plist
+++ b/re-live/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>카메라 권한이 필요합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>스캔한 이미지를 갤러리에 저장하려면 권한이 필요합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>갤러리에서 이미지를 선택하려면 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/re-live/Views/Scan/OCRCameraOverlayView.swift
+++ b/re-live/Views/Scan/OCRCameraOverlayView.swift
@@ -7,58 +7,17 @@
 
 import UIKit
 
-
-//class OCRCameraOverlayView: UIView {
-//    private let instructionLabel = UILabel()
-//    private let guideLayer = CAShapeLayer()
-//
-//    override init(frame: CGRect) {
-//        super.init(frame: frame)
-//        setupView()
-//    }
-//
-//    required init?(coder: NSCoder) {
-//        super.init(coder: coder)
-//        setupView()
-//    }
-//
-//    private func setupView() {
-//        backgroundColor = .clear
-//
-//        instructionLabel.text = "Align the document within the frame"
-//        instructionLabel.textColor = .white
-//        instructionLabel.textAlignment = .center
-//        instructionLabel.translatesAutoresizingMaskIntoConstraints = false
-//        addSubview(instructionLabel)
-//
-//        NSLayoutConstraint.activate([
-//            instructionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -20),
-//            instructionLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
-//        ])
-//
-//        guideLayer.strokeColor = UIColor.yellow.cgColor
-//        guideLayer.fillColor = UIColor.clear.cgColor
-//        guideLayer.lineWidth = 2
-//        layer.addSublayer(guideLayer)
-//    }
-//
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//        let rect = bounds.insetBy(dx: 40, dy: 100)
-//        guideLayer.path = UIBezierPath(rect: rect).cgPath
-//    }
-//}
-
-
 final class OCRCameraOverlayView: UIView {
     private let frameView = UIView()
     private let scanLine = UIView()
     private let titleLabel = UILabel()
     private let subtitleLabel = UILabel()
     private let borderLayer = CAShapeLayer()
+    public let galleryButton = UIButton()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        self.isUserInteractionEnabled = false
         setupView()
     }
 
@@ -72,7 +31,6 @@ final class OCRCameraOverlayView: UIView {
 
         frameView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(frameView)
-
         frameView.layer.addSublayer(borderLayer)
 
         scanLine.backgroundColor = UIColor.systemBlue
@@ -90,6 +48,11 @@ final class OCRCameraOverlayView: UIView {
         subtitleLabel.font = .systemFont(ofSize: 14)
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(subtitleLabel)
+        
+        galleryButton.translatesAutoresizingMaskIntoConstraints = false
+        galleryButton.setImage(UIImage(systemName: "photo.on.rectangle"), for: .normal)
+        galleryButton.tintColor = .white
+        addSubview(galleryButton)
 
         NSLayoutConstraint.activate([
             frameView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -106,7 +69,14 @@ final class OCRCameraOverlayView: UIView {
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
 
             subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
-            subtitleLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
+            subtitleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            
+            galleryButton.widthAnchor.constraint(equalToConstant: 64),
+            galleryButton.heightAnchor.constraint(equalToConstant: 64),
+            galleryButton.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -50),
+            galleryButton.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+
+            
         ])
     }
 
@@ -130,4 +100,9 @@ final class OCRCameraOverlayView: UIView {
         animation.repeatCount = .infinity
         scanLine.layer.add(animation, forKey: "scan")
     }
+    
+    func setGalleryButtonTarget(_ target: Any?, action: Selector, for event: UIControl.Event) {
+        galleryButton.addTarget(target, action: action, for: event)
+    }
+    
 }

--- a/re-live/Views/Scan/ScanViewController.swift
+++ b/re-live/Views/Scan/ScanViewController.swift
@@ -11,53 +11,72 @@ import VisionKit
 class ScanViewController: UIViewController, VNDocumentCameraViewControllerDelegate {
     private let viewModel: ScanViewModel
     private let overlay = OCRCameraOverlayView()
-
+    
     init(viewModel: ScanViewModel = ScanViewModel()) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         presentDocumentCamera()
-    }
 
-    private func presentDocumentCamera() {
+    }
+    
+    @objc private func presentDocumentCamera() {
         guard VNDocumentCameraViewController.isSupported else { return }
         let cameraViewController = VNDocumentCameraViewController()
         cameraViewController.delegate = self
         cameraViewController.view.addSubview(overlay)
         overlay.frame = cameraViewController.view.bounds
         overlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+//        overlay.galleryButton.addTarget(self, action: #selector(openPhotoLibrary), for: .touchUpInside)
         present(cameraViewController, animated: true, completion: nil)
+        
     }
-
+    
+    @objc private func openPhotoLibrary() {
+        let picker = UIImagePickerController()
+        picker.delegate = self
+        picker.sourceType = .photoLibrary
+        picker.allowsEditing = false
+        present(picker, animated: true, completion: nil)
+    }
+    
     func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
         controller.dismiss(animated: true, completion: nil)
     }
-
+    
     func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
         controller.dismiss(animated: true) {
             self.viewModel.handleError(error)
         }
     }
-
+    
     func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
         var images: [UIImage] = []
         for index in 0..<scan.pageCount {
             images.append(scan.imageOfPage(at: index))
         }
+        
         controller.dismiss(animated: true) {
             self.viewModel.performOCR(on: images)
+        }
+    }
+    
+}
+
+extension ScanViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        picker.dismiss(animated: true){
+            if let image = info[.originalImage] as? UIImage {
+                self.viewModel.performOCR(on: [image])
+            }
         }
     }
 }


### PR DESCRIPTION
**[실험] 카메라 오버레이 뷰 시도 구조 구현**

개요
VNDocumentCameraViewController 위에 직접 오버레이 뷰(OCRCameraOverlayView)를 덧붙이는 구조 실험
안내 UI 및 스캔 애니메이션 시도

주요 내용
스캔 라인, 라벨, 갤러리 버튼 포함된 overlay 구성
카메라 present 후 오버레이 추가
**까만화면 오류 해결**

한계 및 다음 방향
내부 화면 전환(VNDocumentCameraViewController → 결과 미리보기)에서 오버레이가 사라지지 않음
터치 방해 및 상태 감지의 불안정성 있음
**→ 본 구조는 폐기 예정이며, 추후 별도 선택 화면(UI)에서 '갤러리 선택' / '카메라 촬영' 분기 구조로 전환 예정**